### PR TITLE
Hotfix: Announce roles as innocent per default

### DIFF
--- a/lua/autorun/rv_init.lua
+++ b/lua/autorun/rv_init.lua
@@ -67,7 +67,8 @@ else
 		local rls = {}
 
 		for i = 1, tblSize do
-			rls[net.ReadUInt(ROLE_BITS)] = net.ReadUInt(32)
+			local role = net.ReadUInt(ROLE_BITS)
+			rls[role] = net.ReadUInt(32)
 		end
 
 		local spectators = net.ReadUInt(9)

--- a/lua/autorun/rv_init.lua
+++ b/lua/autorun/rv_init.lua
@@ -67,8 +67,7 @@ else
 		local rls = {}
 
 		for i = 1, tblSize do
-			local role = net.ReadUInt(ROLE_BITS)
-			rls[role] = net.ReadUInt(32)
+			rls[net.ReadUInt(ROLE_BITS)] = net.ReadUInt(32)
 		end
 
 		local spectators = net.ReadUInt(9)

--- a/lua/autorun/server/tttchatpeople.lua
+++ b/lua/autorun/server/tttchatpeople.lua
@@ -28,6 +28,10 @@ function TellRoles()
 			table.insert(rolesnames[role], v:Nick())
 
 			role = role == ROLE_DETECTIVE and ROLE_INNOCENT or role
+			
+			if TTT2 then
+				role = v:HasTeam(TEAM_TRAITOR) and ROLE_TRAITOR or ROLE_INNOCENT
+			end
 
 			rls[role] = (rls[role] or 0) + 1
 		end

--- a/lua/autorun/server/tttchatpeople.lua
+++ b/lua/autorun/server/tttchatpeople.lua
@@ -1,23 +1,28 @@
 function TellRoles()
 	local rolesnames = {}
 	local rls = {}
+	local printrls = {}
 	local spectators = 0
-
+	
 	if not TTT2 then
 		rls[ROLE_INNOCENT] = 0
 		rls[ROLE_TRAITOR] = 0
-		rls[ROLE_DETECTIVE] = 0 -- not needed
-
+		
 		rolesnames[ROLE_INNOCENT] = {}
 		rolesnames[ROLE_TRAITOR] = {}
 		rolesnames[ROLE_DETECTIVE] = {}
 	else
 		for _, v in pairs(GetRoles()) do
 			rls[v.index] = 0
-
+			printrls[v.index] = false
+			
 			rolesnames[v.index] = {}
 		end
 	end
+	
+	printrls[ROLE_INNOCENT] = true
+	printrls[ROLE_TRAITOR] = true
+	
 
 	for _, v in ipairs(player.GetAll()) do
 		if not v:Alive() or not v:IsTerror() then
@@ -27,18 +32,19 @@ function TellRoles()
 
 			table.insert(rolesnames[role], v:Nick())
 
-			role = role == ROLE_DETECTIVE and ROLE_INNOCENT or role
-			
-			if TTT2 then
-				role = v:HasTeam(TEAM_TRAITOR) and ROLE_TRAITOR or ROLE_INNOCENT
-			end
-
 			rls[role] = (rls[role] or 0) + 1
 		end
 	end
 
-	hook.Run("TTTAModifyRolesTable", rls)
+	hook.Run("TTTAModifyRolesTable", rls, printrls)
 
+	--add non used roles to innocent
+	for role, do_print in pairs(printrls) do
+		if not do_print then
+			rls[ROLE_INNOCENT] = rls[ROLE_INNOCENT] + (rls[role] or 0)
+		end
+	end
+	
 	rolesnamestext = {}
 
 	for role, nicks in pairs(rolesnames) do


### PR DESCRIPTION
* Added printrls table to hook to allow further modifications
* Improved for extensibility in case we maybe do want announce special roles later on (could be easily implemented client-side now)