### PR TITLE
Fix killer weapon type and icon

### DIFF
--- a/lua/autorun/client/cl_roundinfo_handler.lua
+++ b/lua/autorun/client/cl_roundinfo_handler.lua
@@ -1,27 +1,32 @@
 if CLIENT then
     KILLER_INFO = {}
 
-    KILLER_INFO.data = {
-        render = false,
-        mode = 'killer_self',
-        killer_name = 'KILLER_NAME',
-        killer_sid64 = '',
-        killer_icon = Material('vgui/ttt/avatar_killer_world'),
-        killer_role = 'inno',
-        killer_role_lang = '',
-        killer_role_color = Color(120,255,80),
-        killer_role_icon = Material('vgui/ttt/dynamic/roles/icon_inno'),
-        killer_health = 0,
-        killer_max_health = 100,
-        killer_weapon_name = 'WEAPON_NAME',
-        killer_weapon_clip = 0,
-        killer_weapon_clip_max = 0,
-        killer_weapon_ammo = 0,
-        killer_weapon_icon = Material('vgui/ttt/icon_nades'),
-        killer_weapon_head = false,
-        damage_type_name = 'TYPE',
-        damage_type_icon = Material('vgui/ttt/icon_skull')
-    }
+    function KILLER_INFO:Reset()
+        KILLER_INFO.data = {
+            render = false,
+            mode = 'killer_self',
+            killer_name = 'KILLER_NAME',
+            killer_sid64 = '',
+            killer_icon = Material('vgui/ttt/avatar_killer_world'),
+            killer_role = 'inno',
+            killer_role_lang = '',
+            killer_role_color = Color(120,255,80),
+            killer_role_icon = Material('vgui/ttt/dynamic/roles/icon_inno'),
+            killer_health = 0,
+            killer_max_health = 100,
+            killer_weapon_name = 'WEAPON_NAME',
+            killer_weapon_clip = 0,
+            killer_weapon_clip_max = 0,
+            killer_weapon_ammo = 0,
+            killer_weapon_icon = Material('vgui/ttt/icon_nades'),
+            killer_weapon_head = false,
+            damage_type_name = 'TYPE',
+            damage_type_icon = Material('vgui/ttt/icon_skull')
+        }
+    end
+
+    -- Initialize KILLER_INFO with default values
+    KILLER_INFO:Reset()
 
     function KILLER_INFO:RegisterKiller(name, sid64, role, role_lang, role_color, health, health_max)
         self.data.killer_name = name
@@ -129,6 +134,7 @@ if CLIENT then
 
     function KILLER_INFO:HidePopup()
         self.data.render = false
+        KILLER_INFO:Reset()
 
         if timer.Exists('display_popup') then
             timer.Remove('display_popup')
@@ -166,7 +172,7 @@ if CLIENT then
     function KILLER_INFO:PrintSelf()
         if (GAMEMODE.round_state ~= ROUND_ACTIVE and GAMEMODE.round_state ~= ROUND_POST) then return end
 
-        local txt = LANG.GetParamTranslation('ttt_rs_suicideText', {killtype = self.data.killer_weapon_name != 'WEAPON_NAME' and self.data.killer_weapon_name or self.data.damage_type_name})
+        local txt = LANG.GetParamTranslation('ttt_rs_suicideText', {killtype = not self.data.killer_weapon_name == 'WEAPON_NAME' and self.data.killer_weapon_name or self.data.damage_type_name})
         self:PrintColor(txt)
     end
 

--- a/lua/autorun/client/cl_roundinfo_handler.lua
+++ b/lua/autorun/client/cl_roundinfo_handler.lua
@@ -172,7 +172,7 @@ if CLIENT then
     function KILLER_INFO:PrintSelf()
         if (GAMEMODE.round_state ~= ROUND_ACTIVE and GAMEMODE.round_state ~= ROUND_POST) then return end
 
-        local txt = LANG.GetParamTranslation('ttt_rs_suicideText', {killtype = not self.data.killer_weapon_name == 'WEAPON_NAME' and self.data.killer_weapon_name or self.data.damage_type_name})
+        local txt = LANG.GetParamTranslation('ttt_rs_suicideText', {killtype = self.data.killer_weapon_name ~= 'WEAPON_NAME' and self.data.killer_weapon_name or self.data.damage_type_name})
         self:PrintColor(txt)
     end
 

--- a/lua/autorun/client/cl_roundinfo_handler.lua
+++ b/lua/autorun/client/cl_roundinfo_handler.lua
@@ -166,7 +166,7 @@ if CLIENT then
     function KILLER_INFO:PrintSelf()
         if (GAMEMODE.round_state ~= ROUND_ACTIVE and GAMEMODE.round_state ~= ROUND_POST) then return end
 
-        local txt = LANG.GetParamTranslation('ttt_rs_suicideText', {killtype = self.data.damage_type_name})
+        local txt = LANG.GetParamTranslation('ttt_rs_suicideText', {killtype = self.data.killer_weapon_name != 'WEAPON_NAME' and self.data.killer_weapon_name or self.data.damage_type_name})
         self:PrintColor(txt)
     end
 

--- a/lua/autorun/client/cl_roundinfo_handler.lua
+++ b/lua/autorun/client/cl_roundinfo_handler.lua
@@ -1,28 +1,34 @@
 if CLIENT then
     KILLER_INFO = {}
 
+    local KILLER_INFO_FALLBACK_DATA = {
+        render = false,
+        mode = 'killer_self',
+        killer_name = 'KILLER_NAME',
+        killer_sid64 = '',
+        killer_icon = Material('vgui/ttt/avatar_killer_world'),
+        killer_role = 'inno',
+        killer_role_lang = '',
+        killer_role_color = Color(120,255,80),
+        killer_role_icon = Material('vgui/ttt/dynamic/roles/icon_inno'),
+        killer_health = 0,
+        killer_max_health = 100,
+        killer_weapon_name = 'WEAPON_NAME',
+        killer_weapon_clip = 0,
+        killer_weapon_clip_max = 0,
+        killer_weapon_ammo = 0,
+        killer_weapon_icon = Material('vgui/ttt/icon_nades'),
+        killer_weapon_head = false,
+        damage_type_name = 'TYPE',
+        damage_type_icon = Material('vgui/ttt/icon_skull')
+    }
+
+    KILLER_INFO_FALLBACK_DATA.__index = KILLER_INFO_FALLBACK_DATA
+
     function KILLER_INFO:Reset()
-        KILLER_INFO.data = {
-            render = false,
-            mode = 'killer_self',
-            killer_name = 'KILLER_NAME',
-            killer_sid64 = '',
-            killer_icon = Material('vgui/ttt/avatar_killer_world'),
-            killer_role = 'inno',
-            killer_role_lang = '',
-            killer_role_color = Color(120,255,80),
-            killer_role_icon = Material('vgui/ttt/dynamic/roles/icon_inno'),
-            killer_health = 0,
-            killer_max_health = 100,
-            killer_weapon_name = 'WEAPON_NAME',
-            killer_weapon_clip = 0,
-            killer_weapon_clip_max = 0,
-            killer_weapon_ammo = 0,
-            killer_weapon_icon = Material('vgui/ttt/icon_nades'),
-            killer_weapon_head = false,
-            damage_type_name = 'TYPE',
-            damage_type_icon = Material('vgui/ttt/icon_skull')
-        }
+        KILLER_INFO.data = {}
+
+        setmetatable(KILLER_INFO.data, KILLER_INFO_FALLBACK_DATA)
     end
 
     -- Initialize KILLER_INFO with default values

--- a/lua/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/autorun/client/cl_roundinfo_receive.lua
@@ -85,8 +85,9 @@ if CLIENT then
 			KILLER_INFO:RegisterKiller(killer_nick, killer_sid64, killer_role, killer_role_lang, killer_role_color, killer_health, killer_health_max)
 		end
 
-		local wep_class = net.ReadEntity()
-		if not IsValid(wep_class) or not wep_class then
+		local hasWeapon = net.ReadUInt(1) == 1
+
+		if !hasWeapon then
 			if killer_type == 1 then
 				if killer_popup then KILLER_INFO:DisplayPopupKillerNoWeapon(display_time) end
 				if killer_text then KILLER_INFO:PrintKillerNoWeapon() end
@@ -98,19 +99,16 @@ if CLIENT then
 			return
 		end
 
+		local wep_className = net.ReadString()
+		local wep_class = weapons.GetStored(wep_className) or {}
+		local wep_name = wep_class.PrintName or wep_className
+		local wep_icon = wep_class.Icon or 'vgui/ttt/icon_nades'
 		local wep_clip = net.ReadInt(16)
 		local wep_clip_max = net.ReadInt(16)
 		local wep_ammo = net.ReadInt(16)
 		local was_headshot = net.ReadBool()
 
-		local wep_name = ''
-		if wep_class['GetPrintName'] == nil then
-			wep_name = wep_class.PrintName or wep_class:GetClass() or '...'
-		else
-			wep_name = wep_class:GetPrintName() or wep_class.PrintName or wep_class:GetClass() or '...'
-		end
-
-		KILLER_INFO:RegisterWeapon(wep_name, wep_clip, wep_clip_max, wep_ammo, wep_class.Icon or 'vgui/ttt/icon_nades', was_headshot)
+		KILLER_INFO:RegisterWeapon(wep_name, wep_clip, wep_clip_max, wep_ammo, wep_icon, was_headshot)
 
 		if killer_type == 1 then
 			if killer_popup then KILLER_INFO:DisplayPopupKillerWeapon(display_time) end

--- a/lua/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/autorun/client/cl_roundinfo_receive.lua
@@ -41,20 +41,16 @@ if CLIENT then
 		if bit.band(damage_type, DMG_CRUSH) == DMG_CRUSH then
 			damage_type_icon_path = 'vgui/ttt/icon_rock'
 			damage_type_name_lang = 'ttt_rs_killtype_propkill'
-		end
-		if bit.band(damage_type, DMG_FALL) == DMG_FALL then
+		elseif bit.band(damage_type, DMG_FALL) == DMG_FALL then
 			damage_type_icon_path = 'vgui/ttt/icon_fall'
 			damage_type_name_lang = 'ttt_rs_killtype_falldamage'
-		end
-		if bit.band(damage_type, DMG_BURN) == DMG_BURN then
+		elseif bit.band(damage_type, DMG_BURN) == DMG_BURN then
 			damage_type_icon_path = 'vgui/ttt/icon_fire'
 			damage_type_name_lang = 'ttt_rs_killtype_firedamage'
-		end
-		if bit.band(damage_type, DMG_BLAST) == DMG_BLAST then
+		elseif bit.band(damage_type, DMG_BLAST) == DMG_BLAST then
 			damage_type_icon_path = 'vgui/ttt/icon_splode'
 			damage_type_name_lang = 'ttt_rs_killtype_explosion'
-		end
-		if bit.band(damage_type, DMG_DROWN) == DMG_DROWN then
+		elseif bit.band(damage_type, DMG_DROWN) == DMG_DROWN then
 			damage_type_icon_path = 'vgui/ttt/icon_drown'
 			damage_type_name_lang = 'ttt_rs_killtype_drowned'
 		end
@@ -102,8 +98,7 @@ if CLIENT then
 				if killer_type == 1 then
 					if killer_popup then KILLER_INFO:DisplayPopupKillerWeapon(display_time) end
 					if killer_text then KILLER_INFO:PrintKillerWeapon() end
-				end
-				if killer_type == 2 then
+				elseif killer_type == 2 then
 					if killer_popup then KILLER_INFO:DisplayPopupSelfWeapon(display_time) end
 					if killer_text then KILLER_INFO:PrintSelf() end
 				end
@@ -114,8 +109,7 @@ if CLIENT then
 		if killer_type == 1 then
 			if killer_popup then KILLER_INFO:DisplayPopupKillerNoWeapon(display_time) end
 			if killer_text then KILLER_INFO:PrintKillerNoWeapon() end
-		end
-		if killer_type == 2 then
+		elseif killer_type == 2 then
 			if killer_popup then KILLER_INFO:DisplayPopupSelfNoWeapon(display_time) end
 			if killer_text then KILLER_INFO:PrintSelf() end
 		end

--- a/lua/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/autorun/client/cl_roundinfo_receive.lua
@@ -85,37 +85,38 @@ if CLIENT then
 			KILLER_INFO:RegisterKiller(killer_nick, killer_sid64, killer_role, killer_role_lang, killer_role_color, killer_health, killer_health_max)
 		end
 
-		local hasWeapon = net.ReadUInt(1) == 1
+		local hasWeapon = net.ReadBool()
+		if hasWeapon then
+			local wep_className = net.ReadString()
+			local wep_class = weapons.GetStored(wep_className)
+			if wep_class then
+				local wep_name = wep_class.PrintName or wep_className
+				local wep_icon = wep_class.Icon or 'vgui/ttt/icon_nades'
+				local wep_clip = net.ReadInt(16)
+				local wep_clip_max = net.ReadInt(16)
+				local wep_ammo = net.ReadInt(16)
+				local was_headshot = net.ReadBool()
 
-		if !hasWeapon then
-			if killer_type == 1 then
-				if killer_popup then KILLER_INFO:DisplayPopupKillerNoWeapon(display_time) end
-				if killer_text then KILLER_INFO:PrintKillerNoWeapon() end
+				KILLER_INFO:RegisterWeapon(wep_name, wep_clip, wep_clip_max, wep_ammo, wep_icon, was_headshot)
+
+				if killer_type == 1 then
+					if killer_popup then KILLER_INFO:DisplayPopupKillerWeapon(display_time) end
+					if killer_text then KILLER_INFO:PrintKillerWeapon() end
+				end
+				if killer_type == 2 then
+					if killer_popup then KILLER_INFO:DisplayPopupSelfWeapon(display_time) end
+					if killer_text then KILLER_INFO:PrintSelf() end
+				end
+				return
 			end
-			if killer_type == 2 then
-				if killer_popup then KILLER_INFO:DisplayPopupSelfNoWeapon(display_time) end
-				if killer_text then KILLER_INFO:PrintSelf() end
-			end
-			return
 		end
-
-		local wep_className = net.ReadString()
-		local wep_class = weapons.GetStored(wep_className) or {}
-		local wep_name = wep_class.PrintName or wep_className
-		local wep_icon = wep_class.Icon or 'vgui/ttt/icon_nades'
-		local wep_clip = net.ReadInt(16)
-		local wep_clip_max = net.ReadInt(16)
-		local wep_ammo = net.ReadInt(16)
-		local was_headshot = net.ReadBool()
-
-		KILLER_INFO:RegisterWeapon(wep_name, wep_clip, wep_clip_max, wep_ammo, wep_icon, was_headshot)
 
 		if killer_type == 1 then
-			if killer_popup then KILLER_INFO:DisplayPopupKillerWeapon(display_time) end
-			if killer_text then KILLER_INFO:PrintKillerWeapon() end
+			if killer_popup then KILLER_INFO:DisplayPopupKillerNoWeapon(display_time) end
+			if killer_text then KILLER_INFO:PrintKillerNoWeapon() end
 		end
 		if killer_type == 2 then
-			if killer_popup then KILLER_INFO:DisplayPopupSelfWeapon(display_time) end
+			if killer_popup then KILLER_INFO:DisplayPopupSelfNoWeapon(display_time) end
 			if killer_text then KILLER_INFO:PrintSelf() end
 		end
 	end)

--- a/lua/autorun/server/sv_roundinfo_send.lua
+++ b/lua/autorun/server/sv_roundinfo_send.lua
@@ -130,6 +130,7 @@ if SERVER then
 		local wep_class = util.WeaponFromDamage(dmg)
 
 		if not IsValid(wep_class) or not wep_class then
+			net.WriteUInt(0, 1) -- Has Weapon : FALSE
 			net.Send(victim)
 			return
 		end
@@ -157,8 +158,9 @@ if SERVER then
 			wep_clip_max = math.floor(wep_clip_max)
 			wep_ammo = math.floor(wep_ammo)
 		end
-			
-		net.WriteEntity(wep_class)
+
+		net.WriteUInt(1, 1) -- Has Weapon : TRUE
+		net.WriteString(wep_class:GetClass() or 'undefined')
 		net.WriteInt(wep_clip, 16)
 		net.WriteInt(wep_clip_max, 16)
 		net.WriteInt(wep_ammo, 16)

--- a/lua/autorun/server/sv_roundinfo_send.lua
+++ b/lua/autorun/server/sv_roundinfo_send.lua
@@ -130,7 +130,7 @@ if SERVER then
 		local wep_class = util.WeaponFromDamage(dmg)
 
 		if not IsValid(wep_class) or not wep_class then
-			net.WriteUInt(0, 1) -- Has Weapon : FALSE
+			net.WriteBool(false)
 			net.Send(victim)
 			return
 		end
@@ -159,7 +159,7 @@ if SERVER then
 			wep_ammo = math.floor(wep_ammo)
 		end
 
-		net.WriteUInt(1, 1) -- Has Weapon : TRUE
+		net.WriteBool(true)
 		net.WriteString(wep_class:GetClass() or 'undefined')
 		net.WriteInt(wep_clip, 16)
 		net.WriteInt(wep_clip_max, 16)


### PR DESCRIPTION
Uses local stored weapon entity by class instead of sending entity id. Properly shows the weapon you were killed by and its icon in chat and info popup.