### PR TITLE
Added detailed role distribution overview at the beginning of a round as an optional convar

### DIFF
--- a/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
@@ -27,6 +27,27 @@ if CLIENT then
 		chat.AddText(unpack(arr)) -- convert table to list of vars
 	end)
 
+	net.Receive("tttRsTellPreDetailed", function(len)
+		local defcolor = Color(255, 255, 255, 255)
+		local T = LANG.GetTranslation
+		local rolesnames = {}
+		local rolesSize = net.ReadUInt(ROLE_BITS)
+		for i = 1, rolesSize do
+			local role = net.ReadUInt(ROLE_BITS)
+			local names = net.ReadString()
+			rolesnames[role] = names
+		end
+
+		chat.AddText(defcolor, LANG.GetTranslation("ttt_rs_preDetailedText"))
+		for role, names in pairs(rolesnames) do
+			local rd = GetRoleByIndex(role)
+			if rd then
+				local txt = string.format(" %s: %s", T(rd.name), names)
+				chat.AddText(rd.color, txt)
+			end
+		end
+	end)
+
 	net.Receive("tttRsDeathNotify", function(len)
 		-- how long should the panel be displayed
 		local display_time = net.ReadUInt(16)

--- a/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
@@ -43,9 +43,13 @@ if CLIENT then
 
 		local spectators = net.ReadUInt(9)
 		
-		-- Build message parts
-		local messageParts = {defcolor, T("ttt_rs_preText_combined")}
-		
+		-- Build message parts starting with header
+		local messageParts = {
+			defcolor, 
+			T("ttt_rs_preText_combined"),
+			"\n" -- Start first role on new line
+		}
+
 		-- Add roles
 		local sortedRoles = {}
 		for role in pairs(rolecounts) do
@@ -60,22 +64,23 @@ if CLIENT then
 			local count = rolecounts[role]
 			local rd = GetRoleByIndex(role)
 			if count > 0 and rd then
-				if i > 1 then
-					table.insert(messageParts, defcolor)
-					table.insert(messageParts, ", ")
-				end
+				-- Add role line
 				table.insert(messageParts, rd.color)
 				table.insert(messageParts, T(rd.name))
 				table.insert(messageParts, defcolor)
 				table.insert(messageParts, ": ")
 				table.insert(messageParts, namecolor)
 				table.insert(messageParts, tostring(count))
+				
+				-- Add newline for next role (except after last role)
+				if i < #sortedRoles then
+					table.insert(messageParts, "\n")
+				end
 			end
 		end
 
-		-- Add spectators
-		table.insert(messageParts, defcolor)
-		table.insert(messageParts, ", ")
+		-- Add spectators on new line
+		table.insert(messageParts, "\n")
 		table.insert(messageParts, team.GetColor(TEAM_SPEC))
 		table.insert(messageParts, T("spectators"))
 		table.insert(messageParts, defcolor)

--- a/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
@@ -28,24 +28,31 @@ if CLIENT then
 	end)
 
 	net.Receive("tttRsTellPreDetailed", function(len)
-		local defcolor = Color(255, 255, 255, 255)
-		local T = LANG.GetTranslation
-		local rolesnames = {}
-		local rolesSize = net.ReadUInt(ROLE_BITS)
-		for i = 1, rolesSize do
-			local role = net.ReadUInt(ROLE_BITS)
-			local names = net.ReadString()
-			rolesnames[role] = names
-		end
-
-		chat.AddText(defcolor, LANG.GetTranslation("ttt_rs_preDetailedText"))
-		for role, names in pairs(rolesnames) do
-			local rd = GetRoleByIndex(role)
-			if rd then
-				local txt = string.format(" %s: %s", T(rd.name), names)
-				chat.AddText(rd.color, txt)
-			end
-		end
+	    local defcolor = Color(255, 255, 255, 255)
+	    local T = LANG.GetTranslation
+	    local rolecounts = {}
+	    local rolesSize = net.ReadUInt(ROLE_BITS)
+	
+	    for i = 1, rolesSize do
+	        local role = net.ReadUInt(ROLE_BITS)
+	        local count = net.ReadUInt(32)  -- Read count instead of names
+	        rolecounts[role] = count
+	    end
+	
+	    local parts = {}
+	    for role, count in SortedPairs(rolecounts) do
+	        local rd = GetRoleByIndex(role)
+	        if rd then
+	            table.insert(parts, rd.color)
+	            table.insert(parts, T(rd.name) .. ": " .. count)
+	            table.insert(parts, defcolor)
+	            table.insert(parts, ", ")
+	        end
+	    end
+	    if #parts > 0 then
+	        parts[#parts] = nil  -- Remove trailing comma
+	        chat.AddText(defcolor, LANG.GetTranslation("ttt_rs_preDetailedText"), unpack(parts))
+	    end
 	end)
 
 	net.Receive("tttRsDeathNotify", function(len)

--- a/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
@@ -47,7 +47,7 @@ if CLIENT then
 		local messageParts = {
 			"\n", -- Initial newline
 			defcolor, 
-			T("ttt_rs_preText_combined"),
+			T("ttt_rs_preText_detailed"),
 			"\n" -- Start first role on new line
 		}
 

--- a/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
@@ -28,31 +28,62 @@ if CLIENT then
 	end)
 
 	net.Receive("tttRsTellPreDetailed", function(len)
-	    local defcolor = Color(255, 255, 255, 255)
-	    local T = LANG.GetTranslation
-	    local rolecounts = {}
-	    local rolesSize = net.ReadUInt(ROLE_BITS)
-	
-	    for i = 1, rolesSize do
-	        local role = net.ReadUInt(ROLE_BITS)
-	        local count = net.ReadUInt(32)  -- Read count instead of names
-	        rolecounts[role] = count
-	    end
-	
-	    local parts = {}
-	    for role, count in SortedPairs(rolecounts) do
-	        local rd = GetRoleByIndex(role)
-	        if rd then
-	            table.insert(parts, rd.color)
-	            table.insert(parts, T(rd.name) .. ": " .. count)
-	            table.insert(parts, defcolor)
-	            table.insert(parts, ", ")
-	        end
-	    end
-	    if #parts > 0 then
-	        parts[#parts] = nil  -- Remove trailing comma
-	        chat.AddText(defcolor, LANG.GetTranslation("ttt_rs_preDetailedText"), unpack(parts))
-	    end
+		local defcolor = Color(255, 255, 255, 255)
+		local namecolor = Color(255, 235, 135, 255)
+		local T = LANG.GetTranslation
+		
+		local rolecounts = {}
+		local rolesSize = net.ReadUInt(ROLE_BITS)
+		
+		for i = 1, rolesSize do
+			local role = net.ReadUInt(ROLE_BITS)
+			local count = net.ReadUInt(32)
+			rolecounts[role] = count
+		end
+
+		local spectators = net.ReadUInt(9)
+		
+		-- Build message parts
+		local messageParts = {defcolor, T("ttt_rs_preText_combined")}
+		
+		-- Add roles
+		local sortedRoles = {}
+		for role in pairs(rolecounts) do
+			table.insert(sortedRoles, role)
+		end
+		
+		table.sort(sortedRoles, function(a, b)
+			return GetRoleByIndex(a).index < GetRoleByIndex(b).index
+		end)
+
+		for i, role in ipairs(sortedRoles) do
+			local count = rolecounts[role]
+			local rd = GetRoleByIndex(role)
+			if count > 0 and rd then
+				if i > 1 then
+					table.insert(messageParts, defcolor)
+					table.insert(messageParts, ", ")
+				end
+				table.insert(messageParts, rd.color)
+				table.insert(messageParts, T(rd.name))
+				table.insert(messageParts, defcolor)
+				table.insert(messageParts, ": ")
+				table.insert(messageParts, namecolor)
+				table.insert(messageParts, tostring(count))
+			end
+		end
+
+		-- Add spectators
+		table.insert(messageParts, defcolor)
+		table.insert(messageParts, ", ")
+		table.insert(messageParts, team.GetColor(TEAM_SPEC))
+		table.insert(messageParts, T("spectators"))
+		table.insert(messageParts, defcolor)
+		table.insert(messageParts, ": ")
+		table.insert(messageParts, namecolor)
+		table.insert(messageParts, tostring(spectators))
+
+		chat.AddText(unpack(messageParts))
 	end)
 
 	net.Receive("tttRsDeathNotify", function(len)

--- a/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
+++ b/lua/terrortown/autorun/client/cl_roundinfo_receive.lua
@@ -45,12 +45,14 @@ if CLIENT then
 		
 		-- Build message parts starting with header
 		local messageParts = {
+			"\n", -- Initial newline
 			defcolor, 
 			T("ttt_rs_preText_combined"),
 			"\n" -- Start first role on new line
 		}
 
 		-- Add roles
+		local hasRoles = false
 		local sortedRoles = {}
 		for role in pairs(rolecounts) do
 			table.insert(sortedRoles, role)
@@ -64,6 +66,8 @@ if CLIENT then
 			local count = rolecounts[role]
 			local rd = GetRoleByIndex(role)
 			if count > 0 and rd then
+				hasRoles = true
+				
 				-- Add role line
 				table.insert(messageParts, rd.color)
 				table.insert(messageParts, T(rd.name))
@@ -72,21 +76,20 @@ if CLIENT then
 				table.insert(messageParts, namecolor)
 				table.insert(messageParts, tostring(count))
 				
-				-- Add newline for next role (except after last role)
-				if i < #sortedRoles then
-					table.insert(messageParts, "\n")
-				end
+				-- Add newline for next role
+				table.insert(messageParts, "\n")
 			end
 		end
 
-		-- Add spectators on new line
-		table.insert(messageParts, "\n")
-		table.insert(messageParts, team.GetColor(TEAM_SPEC))
-		table.insert(messageParts, T("spectators"))
-		table.insert(messageParts, defcolor)
-		table.insert(messageParts, ": ")
-		table.insert(messageParts, namecolor)
-		table.insert(messageParts, tostring(spectators))
+		-- Add spectators only if there are any or roles existed
+		if spectators > 0 or hasRoles then
+			table.insert(messageParts, team.GetColor(TEAM_SPEC))
+			table.insert(messageParts, T("spectators"))
+			table.insert(messageParts, defcolor)
+			table.insert(messageParts, ": ")
+			table.insert(messageParts, namecolor)
+			table.insert(messageParts, tostring(spectators))
+		end
 
 		chat.AddText(unpack(messageParts))
 	end)

--- a/lua/terrortown/autorun/server/sv_roundinfo_send.lua
+++ b/lua/terrortown/autorun/server/sv_roundinfo_send.lua
@@ -1,11 +1,11 @@
 if SERVER then
 	local flags = {FCVAR_NOTIFY, FCVAR_ARCHIVE}
 	CreateConVar("ttt_roundinfo_pre_announce_distribution", 1, flags)
+	CreateConVar("ttt_roundinfo_pre_announce_detailed", 0, flags)
 	CreateConVar("ttt_roundinfo_announce_killer", 1, flags)
 	CreateConVar("ttt_roundinfo_popup_killer", 1, flags)
 	CreateConVar("ttt_roundinfo_popup_killer_time", 10, flags)
 	CreateConVar("ttt_roundinfo_post_announce_distribution", 1, flags)
-	CreateConVar("ttt_roundinfo_pre_announce_detailed", 0, flags)
 
 	util.AddNetworkString("tttRsTellPre")
 	util.AddNetworkString("tttRsTellPost")

--- a/lua/terrortown/autorun/server/sv_roundinfo_send.lua
+++ b/lua/terrortown/autorun/server/sv_roundinfo_send.lua
@@ -5,12 +5,14 @@ if SERVER then
 	CreateConVar("ttt_roundinfo_popup_killer", 1, flags)
 	CreateConVar("ttt_roundinfo_popup_killer_time", 10, flags)
 	CreateConVar("ttt_roundinfo_post_announce_distribution", 1, flags)
+	CreateConVar("ttt_roundinfo_pre_announce_detailed", 0, flags)
 
 	util.AddNetworkString("tttRsTellPre")
 	util.AddNetworkString("tttRsTellPost")
 	util.AddNetworkString("tttRsDeathNotify")
 	util.AddNetworkString("tttRsDeathNotifyEnhanced")
 	util.AddNetworkString("tttRsPlayerRespawn")
+	util.AddNetworkString("tttRsTellPreDetailed")
 
 	-- ROUND SETUP INFORMATION
 	function TellRoles()
@@ -67,18 +69,26 @@ if SERVER then
 			end
 		end
 
-		if not GetConVar("ttt_roundinfo_pre_announce_distribution"):GetBool() then return end
+		if GetConVar("ttt_roundinfo_pre_announce_detailed"):GetBool() then
+			net.Start("tttRsTellPreDetailed")
+			net.WriteUInt(table.Count(rolesnamestext), ROLE_BITS)
+			for role, names in pairs(rolesnamestext) do
+				net.WriteUInt(role, ROLE_BITS)
+				net.WriteString(names)
+			end
+			net.Broadcast()
+		elseif GetConVar("ttt_roundinfo_pre_announce_distribution"):GetBool() then
+			net.Start("tttRsTellPre")
+			net.WriteUInt(table.Count(rls), ROLE_BITS)
 
-		net.Start("tttRsTellPre")
-		net.WriteUInt(table.Count(rls), ROLE_BITS)
+			for role, amount in pairs(rls) do
+				net.WriteUInt(role, ROLE_BITS)
+				net.WriteUInt(amount, 32)
+			end
 
-		for role, amount in pairs(rls) do
-			net.WriteUInt(role, ROLE_BITS)
-			net.WriteUInt(amount, 32)
+			net.WriteUInt(spectators, 9)
+			net.Broadcast()
 		end
-
-		net.WriteUInt(spectators, 9)
-		net.Broadcast()
 	end
 	hook.Add("TTTBeginRound", "TTTChatStats", TellRoles)
 

--- a/lua/terrortown/autorun/server/sv_roundinfo_send.lua
+++ b/lua/terrortown/autorun/server/sv_roundinfo_send.lua
@@ -71,10 +71,10 @@ if SERVER then
 
 		if GetConVar("ttt_roundinfo_pre_announce_detailed"):GetBool() then
 			net.Start("tttRsTellPreDetailed")
-			net.WriteUInt(table.Count(rolesnamestext), ROLE_BITS)
-			for role, names in pairs(rolesnamestext) do
+			net.WriteUInt(table.Count(rolesnames), ROLE_BITS)
+			for role, nicks in pairs(rolesnames) do
 				net.WriteUInt(role, ROLE_BITS)
-				net.WriteString(names)
+				net.WriteUInt(#nicks, 32)
 			end
 			net.Broadcast()
 		elseif GetConVar("ttt_roundinfo_pre_announce_distribution"):GetBool() then

--- a/lua/terrortown/autorun/server/sv_roundinfo_send.lua
+++ b/lua/terrortown/autorun/server/sv_roundinfo_send.lua
@@ -69,7 +69,8 @@ if SERVER then
 			end
 		end
 
-		if GetConVar("ttt_roundinfo_pre_announce_detailed"):GetBool() then
+		if GetConVar("ttt_roundinfo_pre_announce_detailed"):GetBool() 
+		and GetConVar("ttt_roundinfo_pre_announce_distribution"):GetBool() then
 			net.Start("tttRsTellPreDetailed")
 			net.WriteUInt(table.Count(rolesnames), ROLE_BITS)
 			for role, nicks in pairs(rolesnames) do

--- a/lua/terrortown/autorun/server/sv_roundinfo_send.lua
+++ b/lua/terrortown/autorun/server/sv_roundinfo_send.lua
@@ -76,6 +76,7 @@ if SERVER then
 				net.WriteUInt(role, ROLE_BITS)
 				net.WriteUInt(#nicks, 32)
 			end
+			net.WriteUInt(spectators, 9)
 			net.Broadcast()
 		elseif GetConVar("ttt_roundinfo_pre_announce_distribution"):GetBool() then
 			net.Start("tttRsTellPre")

--- a/lua/terrortown/lang/de/roundinfo.lua
+++ b/lua/terrortown/lang/de/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("de")
 
 L["ttt_rs_preText"] = "0%Es gibt %1%{traits} Verräter%0%, %2%{innos} Unschuldige%0% und %3%{specs} Zuschauer%0% diese Runde."
-L["ttt_rs_preText_combined"] = "Detaillierte Rollenverteilung diese Runde:"
+L["ttt_rs_preText_detailed"] = "Detaillierte Rollenverteilung diese Runde:"
 L["ttt_rs_postText"] = "Die Rollenverteilung diese Runde:"
 L["ttt_rs_killText"] = "0%Du wurdest von %1%{killer}%0% getötet. Rolle: %2%{role}%0%. (Art: {killtype})"
 L["ttt_rs_suicideText"] = "0%Du hast dich selbst getötet! (Art: {killtype})"

--- a/lua/terrortown/lang/de/roundinfo.lua
+++ b/lua/terrortown/lang/de/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("de")
 
 L["ttt_rs_preText"] = "0%Es gibt %1%{traits} Verräter%0%, %2%{innos} Unschuldige%0% und %3%{specs} Zuschauer%0% diese Runde."
-L["ttt_rs_preText_combined"] = "Rollenverteilung:"
+L["ttt_rs_preText_combined"] = "Detaillierte Rollenverteilung diese Runde:"
 L["ttt_rs_postText"] = "Die Rollenverteilung diese Runde:"
 L["ttt_rs_killText"] = "0%Du wurdest von %1%{killer}%0% getötet. Rolle: %2%{role}%0%. (Art: {killtype})"
 L["ttt_rs_suicideText"] = "0%Du hast dich selbst getötet! (Art: {killtype})"

--- a/lua/terrortown/lang/de/roundinfo.lua
+++ b/lua/terrortown/lang/de/roundinfo.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("de")
 
 L["ttt_rs_preText"] = "0%Es gibt %1%{traits} Verräter%0%, %2%{innos} Unschuldige%0% und %3%{specs} Zuschauer%0% diese Runde."
+L["ttt_rs_preText_combined"] = "Rollenverteilung:"
 L["ttt_rs_postText"] = "Die Rollenverteilung diese Runde:"
 L["ttt_rs_killText"] = "0%Du wurdest von %1%{killer}%0% getötet. Rolle: %2%{role}%0%. (Art: {killtype})"
 L["ttt_rs_suicideText"] = "0%Du hast dich selbst getötet! (Art: {killtype})"

--- a/lua/terrortown/lang/en/roundinfo.lua
+++ b/lua/terrortown/lang/en/roundinfo.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("en")
 
 L["ttt_rs_preText"] = "0%There are %1%{traits} traitors%0%, %2%{innos} innocents%0% and %3%{specs} spectators%0% this round."
+L["ttt_rs_preText_combined"] = "Role distribution:"
 L["ttt_rs_postText"] = "The role distribution this round:"
 L["ttt_rs_killText"] = "0%You were killed by %1%{killer}%0%. Role: %2%{role}%0%. (type: {killtype})"
 L["ttt_rs_suicideText"] = "0%You were killed by someone called yourself... (type: {killtype})"

--- a/lua/terrortown/lang/en/roundinfo.lua
+++ b/lua/terrortown/lang/en/roundinfo.lua
@@ -27,3 +27,5 @@ L["label_roundinfo_post_announce_distribution"] = "Announce Distribution Post-Ro
 L["label_roundinfo_announce_killer"] = "Announce Killer"
 L["label_roundinfo_popup_killer"] = "Show Killer Info"
 L["label_roundinfo_popup_killer_time"] = "Show Killer Info Duration"
+L["ttt_rs_preDetailedText"] = "Detailed role distribution this round:"
+L["label_roundinfo_pre_announce_detailed"] = "Announce Detailed Distribution Pre-Round"

--- a/lua/terrortown/lang/en/roundinfo.lua
+++ b/lua/terrortown/lang/en/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("en")
 
 L["ttt_rs_preText"] = "0%There are %1%{traits} traitors%0%, %2%{innos} innocents%0% and %3%{specs} spectators%0% this round."
-L["ttt_rs_preText_combined"] = "Detailed role distribution this round:"
+L["ttt_rs_preText_detailed"] = "Detailed role distribution this round:"
 L["ttt_rs_postText"] = "The role distribution this round:"
 L["ttt_rs_killText"] = "0%You were killed by %1%{killer}%0%. Role: %2%{role}%0%. (type: {killtype})"
 L["ttt_rs_suicideText"] = "0%You were killed by someone called yourself... (type: {killtype})"
@@ -28,5 +28,4 @@ L["label_roundinfo_post_announce_distribution"] = "Announce Distribution Post-Ro
 L["label_roundinfo_announce_killer"] = "Announce Killer"
 L["label_roundinfo_popup_killer"] = "Show Killer Info"
 L["label_roundinfo_popup_killer_time"] = "Show Killer Info Duration"
-L["ttt_rs_preDetailedText"] = "Detailed role distribution this round:"
 L["label_roundinfo_pre_announce_detailed"] = "Announce Detailed Distribution Pre-Round"

--- a/lua/terrortown/lang/en/roundinfo.lua
+++ b/lua/terrortown/lang/en/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("en")
 
 L["ttt_rs_preText"] = "0%There are %1%{traits} traitors%0%, %2%{innos} innocents%0% and %3%{specs} spectators%0% this round."
-L["ttt_rs_preText_combined"] = "Role distribution:"
+L["ttt_rs_preText_combined"] = "Detailed role distribution this round:"
 L["ttt_rs_postText"] = "The role distribution this round:"
 L["ttt_rs_killText"] = "0%You were killed by %1%{killer}%0%. Role: %2%{role}%0%. (type: {killtype})"
 L["ttt_rs_suicideText"] = "0%You were killed by someone called yourself... (type: {killtype})"

--- a/lua/terrortown/lang/es/roundinfo.lua
+++ b/lua/terrortown/lang/es/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("es")
 
 L["ttt_rs_preText"] = "0%Hay %1%{traits} traidores%0%, %2%{innos} inocentes%0% y %3%{specs} espectadores%0% en esta ronda."
-L["ttt_rs_preText_combined"] = "Distribución de roles:"
+L["ttt_rs_preText_combined"] = "Distribución detallada de roles esta ronda:"
 L["ttt_rs_postText"] = "Distribución de roles en esta ronda:"
 L["ttt_rs_killText"] = "0%Fuiste asesinado por %1%{killer}%0%. Rol: %2%{role}%0%. (causa: {killtype})"
 L["ttt_rs_suicideText"] = "0%Fuiste asesinado por ti mismo... (causa: {killtype})"

--- a/lua/terrortown/lang/es/roundinfo.lua
+++ b/lua/terrortown/lang/es/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("es")
 
 L["ttt_rs_preText"] = "0%Hay %1%{traits} traidores%0%, %2%{innos} inocentes%0% y %3%{specs} espectadores%0% en esta ronda."
-L["ttt_rs_preText_combined"] = "Distribución detallada de roles esta ronda:"
+L["ttt_rs_preText_detailed"] = "Distribución detallada de roles esta ronda:"
 L["ttt_rs_postText"] = "Distribución de roles en esta ronda:"
 L["ttt_rs_killText"] = "0%Fuiste asesinado por %1%{killer}%0%. Rol: %2%{role}%0%. (causa: {killtype})"
 L["ttt_rs_suicideText"] = "0%Fuiste asesinado por ti mismo... (causa: {killtype})"

--- a/lua/terrortown/lang/es/roundinfo.lua
+++ b/lua/terrortown/lang/es/roundinfo.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("es")
 
 L["ttt_rs_preText"] = "0%Hay %1%{traits} traidores%0%, %2%{innos} inocentes%0% y %3%{specs} espectadores%0% en esta ronda."
+L["ttt_rs_preText_combined"] = "Distribución de roles:"
 L["ttt_rs_postText"] = "Distribución de roles en esta ronda:"
 L["ttt_rs_killText"] = "0%Fuiste asesinado por %1%{killer}%0%. Rol: %2%{role}%0%. (causa: {killtype})"
 L["ttt_rs_suicideText"] = "0%Fuiste asesinado por ti mismo... (causa: {killtype})"

--- a/lua/terrortown/lang/fr/roundinfo.lua
+++ b/lua/terrortown/lang/fr/roundinfo.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("fr")
 
 L["ttt_rs_preText"] = "0%Il y a %1%{traits} traitres%0%, %2%{innos} innocents%0% et %3%{specs} spectateurs%0% ce round."
+L["ttt_rs_preText_combined"] = "Répartition des rôles :"
 L["ttt_rs_postText"] = "La répartition des rôles du round:"
 L["ttt_rs_killText"] = "0%Vous avez été tué par %1%{killer}%0%. Rôle: %2%{role}%0%. (type: {killtype})"
 L["ttt_rs_suicideText"] = "0%Vous avez été tué par vous-même... (type: {killtype})"

--- a/lua/terrortown/lang/fr/roundinfo.lua
+++ b/lua/terrortown/lang/fr/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("fr")
 
 L["ttt_rs_preText"] = "0%Il y a %1%{traits} traitres%0%, %2%{innos} innocents%0% et %3%{specs} spectateurs%0% ce round."
-L["ttt_rs_preText_combined"] = "Répartition détaillée des rôles ce round :"
+L["ttt_rs_preText_detailed"] = "Répartition détaillée des rôles ce round :"
 L["ttt_rs_postText"] = "La répartition des rôles du round:"
 L["ttt_rs_killText"] = "0%Vous avez été tué par %1%{killer}%0%. Rôle: %2%{role}%0%. (type: {killtype})"
 L["ttt_rs_suicideText"] = "0%Vous avez été tué par vous-même... (type: {killtype})"

--- a/lua/terrortown/lang/fr/roundinfo.lua
+++ b/lua/terrortown/lang/fr/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("fr")
 
 L["ttt_rs_preText"] = "0%Il y a %1%{traits} traitres%0%, %2%{innos} innocents%0% et %3%{specs} spectateurs%0% ce round."
-L["ttt_rs_preText_combined"] = "Répartition des rôles :"
+L["ttt_rs_preText_combined"] = "Répartition détaillée des rôles ce round :"
 L["ttt_rs_postText"] = "La répartition des rôles du round:"
 L["ttt_rs_killText"] = "0%Vous avez été tué par %1%{killer}%0%. Rôle: %2%{role}%0%. (type: {killtype})"
 L["ttt_rs_suicideText"] = "0%Vous avez été tué par vous-même... (type: {killtype})"

--- a/lua/terrortown/lang/it/roundinfo.lua
+++ b/lua/terrortown/lang/it/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("it")
 
 L["ttt_rs_preText"] = "0%Ci sono %1%{traits} traditori, %2%{innos} innocenti e %3%{specs} spettatori questo round."
-L["ttt_rs_preText_combined"] = "Distribuzione ruoli:"
+L["ttt_rs_preText_combined"] = "Distribuzione dettagliata dei ruoli questo round:"
 L["ttt_rs_postText"] = "La distribuzione dei ruoli questo round:"
 L["ttt_rs_killText"] = "0%Sei stato ucciso da %1%{killer}%0%. Ruolo: %2%{role}%0%. (morte: {killtype})"
 L["ttt_rs_suicideText"] = "0%Ti sei suicidato... (morte: {killtype})"

--- a/lua/terrortown/lang/it/roundinfo.lua
+++ b/lua/terrortown/lang/it/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("it")
 
 L["ttt_rs_preText"] = "0%Ci sono %1%{traits} traditori, %2%{innos} innocenti e %3%{specs} spettatori questo round."
-L["ttt_rs_preText_combined"] = "Distribuzione dettagliata dei ruoli questo round:"
+L["ttt_rs_preText_detailed"] = "Distribuzione dettagliata dei ruoli questo round:"
 L["ttt_rs_postText"] = "La distribuzione dei ruoli questo round:"
 L["ttt_rs_killText"] = "0%Sei stato ucciso da %1%{killer}%0%. Ruolo: %2%{role}%0%. (morte: {killtype})"
 L["ttt_rs_suicideText"] = "0%Ti sei suicidato... (morte: {killtype})"

--- a/lua/terrortown/lang/it/roundinfo.lua
+++ b/lua/terrortown/lang/it/roundinfo.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("it")
 
 L["ttt_rs_preText"] = "0%Ci sono %1%{traits} traditori, %2%{innos} innocenti e %3%{specs} spettatori questo round."
+L["ttt_rs_preText_combined"] = "Distribuzione ruoli:"
 L["ttt_rs_postText"] = "La distribuzione dei ruoli questo round:"
 L["ttt_rs_killText"] = "0%Sei stato ucciso da %1%{killer}%0%. Ruolo: %2%{role}%0%. (morte: {killtype})"
 L["ttt_rs_suicideText"] = "0%Ti sei suicidato... (morte: {killtype})"

--- a/lua/terrortown/lang/ja/roundinfo.lua
+++ b/lua/terrortown/lang/ja/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("ja")
 
 L["ttt_rs_preText"] = "0%このラウンドでは%1%Traitor%0%が{traits}人、%2%Innocent%0%が{innos}人、そして%3%Spectator%0%が{specs}人います。"
-L["ttt_rs_preText_combined"] = "役職内訳:"
+L["ttt_rs_preText_combined"] = "今ラウンドの詳細な役職内訳:"
 L["ttt_rs_postText"] = "このラウンドの役職の内訳:"
 L["ttt_rs_killText"] = "0%あなたは%1%{killer}%0%により殺されました。役職:%2%{role}%0%. (死因:{killtype})"
 L["ttt_rs_suicideText"] = "0%あなたは自滅してしまいました...(死因：{killtype})"

--- a/lua/terrortown/lang/ja/roundinfo.lua
+++ b/lua/terrortown/lang/ja/roundinfo.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("ja")
 
 L["ttt_rs_preText"] = "0%このラウンドでは%1%Traitor%0%が{traits}人、%2%Innocent%0%が{innos}人、そして%3%Spectator%0%が{specs}人います。"
+L["ttt_rs_preText_combined"] = "役職内訳:"
 L["ttt_rs_postText"] = "このラウンドの役職の内訳:"
 L["ttt_rs_killText"] = "0%あなたは%1%{killer}%0%により殺されました。役職:%2%{role}%0%. (死因:{killtype})"
 L["ttt_rs_suicideText"] = "0%あなたは自滅してしまいました...(死因：{killtype})"

--- a/lua/terrortown/lang/ja/roundinfo.lua
+++ b/lua/terrortown/lang/ja/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("ja")
 
 L["ttt_rs_preText"] = "0%このラウンドでは%1%Traitor%0%が{traits}人、%2%Innocent%0%が{innos}人、そして%3%Spectator%0%が{specs}人います。"
-L["ttt_rs_preText_combined"] = "今ラウンドの詳細な役職内訳:"
+L["ttt_rs_preText_detailed"] = "今ラウンドの詳細な役職内訳:"
 L["ttt_rs_postText"] = "このラウンドの役職の内訳:"
 L["ttt_rs_killText"] = "0%あなたは%1%{killer}%0%により殺されました。役職:%2%{role}%0%. (死因:{killtype})"
 L["ttt_rs_suicideText"] = "0%あなたは自滅してしまいました...(死因：{killtype})"

--- a/lua/terrortown/lang/ru/roundinfo.lua
+++ b/lua/terrortown/lang/ru/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("ru")
 
 L["ttt_rs_preText"] = "0%Есть %1%{traits} предателей%0%, %2%{innos} невиновных%0% и %3%{specs} наблюдателей%0% в этом раунде."
-L["ttt_rs_preText_combined"] = "Подробное распределение ролей в этом раунде:"
+L["ttt_rs_preText_detailed"] = "Подробное распределение ролей в этом раунде:"
 L["ttt_rs_postText"] = "Распределение ролей в этом раунде:"
 L["ttt_rs_killText"] = "0%Вы были убиты игроком %1%{killer}%0%. Роль: %2%{role}%0%. (тип: {killtype})"
 L["ttt_rs_suicideText"] = "0%Вы были убиты кем-то или чем-то по имени... (тип: {killtype})"

--- a/lua/terrortown/lang/ru/roundinfo.lua
+++ b/lua/terrortown/lang/ru/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("ru")
 
 L["ttt_rs_preText"] = "0%Есть %1%{traits} предателей%0%, %2%{innos} невиновных%0% и %3%{specs} наблюдателей%0% в этом раунде."
-L["ttt_rs_preText_combined"] = "Распределение ролей:"
+L["ttt_rs_preText_combined"] = "Подробное распределение ролей в этом раунде:"
 L["ttt_rs_postText"] = "Распределение ролей в этом раунде:"
 L["ttt_rs_killText"] = "0%Вы были убиты игроком %1%{killer}%0%. Роль: %2%{role}%0%. (тип: {killtype})"
 L["ttt_rs_suicideText"] = "0%Вы были убиты кем-то или чем-то по имени... (тип: {killtype})"

--- a/lua/terrortown/lang/ru/roundinfo.lua
+++ b/lua/terrortown/lang/ru/roundinfo.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("ru")
 
 L["ttt_rs_preText"] = "0%Есть %1%{traits} предателей%0%, %2%{innos} невиновных%0% и %3%{specs} наблюдателей%0% в этом раунде."
+L["ttt_rs_preText_combined"] = "Распределение ролей:"
 L["ttt_rs_postText"] = "Распределение ролей в этом раунде:"
 L["ttt_rs_killText"] = "0%Вы были убиты игроком %1%{killer}%0%. Роль: %2%{role}%0%. (тип: {killtype})"
 L["ttt_rs_suicideText"] = "0%Вы были убиты кем-то или чем-то по имени... (тип: {killtype})"

--- a/lua/terrortown/lang/zh_hans/roundinfo.lua
+++ b/lua/terrortown/lang/zh_hans/roundinfo.lua
@@ -1,6 +1,7 @@
 local L = LANG.GetLanguageTableReference("zh_hans")
 
 L["ttt_rs_preText"] = "0%本轮有 %1%{traits} 名叛徒%0%,%2%{innos} 名无辜者%0% 和 %3%{specs} 名旁观者%0%."
+L["ttt_rs_preText_combined"] = "角色分配:"
 L["ttt_rs_postText"] = "本轮角色分配:"
 L["ttt_rs_killText"] = "0%你被 %1%{killer}%0% 杀死了. 角色: %2%{role}%0%. (类型: {killtype})"
 L["ttt_rs_suicideText"] = "0%你被一个自称为你的人杀死了......(类型: {killtype})"

--- a/lua/terrortown/lang/zh_hans/roundinfo.lua
+++ b/lua/terrortown/lang/zh_hans/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("zh_hans")
 
 L["ttt_rs_preText"] = "0%本轮有 %1%{traits} 名叛徒%0%,%2%{innos} 名无辜者%0% 和 %3%{specs} 名旁观者%0%."
-L["ttt_rs_preText_combined"] = "角色分配:"
+L["ttt_rs_preText_combined"] = "本轮详细角色分配:"
 L["ttt_rs_postText"] = "本轮角色分配:"
 L["ttt_rs_killText"] = "0%你被 %1%{killer}%0% 杀死了. 角色: %2%{role}%0%. (类型: {killtype})"
 L["ttt_rs_suicideText"] = "0%你被一个自称为你的人杀死了......(类型: {killtype})"

--- a/lua/terrortown/lang/zh_hans/roundinfo.lua
+++ b/lua/terrortown/lang/zh_hans/roundinfo.lua
@@ -1,7 +1,7 @@
 local L = LANG.GetLanguageTableReference("zh_hans")
 
 L["ttt_rs_preText"] = "0%本轮有 %1%{traits} 名叛徒%0%,%2%{innos} 名无辜者%0% 和 %3%{specs} 名旁观者%0%."
-L["ttt_rs_preText_combined"] = "本轮详细角色分配:"
+L["ttt_rs_preText_detailed"] = "本轮详细角色分配:"
 L["ttt_rs_postText"] = "本轮角色分配:"
 L["ttt_rs_killText"] = "0%你被 %1%{killer}%0% 杀死了. 角色: %2%{role}%0%. (类型: {killtype})"
 L["ttt_rs_suicideText"] = "0%你被一个自称为你的人杀死了......(类型: {killtype})"

--- a/lua/terrortown/menus/gamemode/server_addons/roundinfo.lua
+++ b/lua/terrortown/menus/gamemode/server_addons/roundinfo.lua
@@ -12,6 +12,11 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	chatmsgs:MakeCheckBox({
+		serverConvar = "ttt_roundinfo_pre_announce_detailed",
+		label = "label_roundinfo_pre_announce_detailed"
+	})
+
+	chatmsgs:MakeCheckBox({
 		serverConvar = "ttt_roundinfo_post_announce_distribution",
 		label = "label_roundinfo_post_announce_distribution"
 	})

--- a/lua/terrortown/menus/gamemode/server_addons/roundinfo.lua
+++ b/lua/terrortown/menus/gamemode/server_addons/roundinfo.lua
@@ -6,14 +6,17 @@ CLGAMEMODESUBMENU.title = "submenu_server_addons_roundinfo_title"
 function CLGAMEMODESUBMENU:Populate(parent)
 	local chatmsgs = vgui.CreateTTT2Form(parent, "header_addons_roundinfo_chat")
 
-	chatmsgs:MakeCheckBox({
+	-- Create basic distribution checkbox first
+	local distributionCheck = chatmsgs:MakeCheckBox({
 		serverConvar = "ttt_roundinfo_pre_announce_distribution",
 		label = "label_roundinfo_pre_announce_distribution"
 	})
 
+	-- Detailed announcement depends on basic distribution being enabled
 	chatmsgs:MakeCheckBox({
 		serverConvar = "ttt_roundinfo_pre_announce_detailed",
-		label = "label_roundinfo_pre_announce_detailed"
+		label = "label_roundinfo_pre_announce_detailed",
+		master = distributionCheck  -- Only enabled when distribution is checked
 	})
 
 	chatmsgs:MakeCheckBox({


### PR DESCRIPTION
# PR Changes Summary

## General Overview
- **Feature Addition:** Detailed role information is now shown at the beginning of the round.

## Client-Side Changes
  - Added message parts to construct the announcement with proper color coding.
  - New logic formats each role on a separate line.

## Server-Side Changes
  - Introduced the new network message `tttRsTellPreDetailed` to transmit detailed role distributions.

## Language File Updates
Language files have been updated across multiple locales to support the new detailed announcement.

## UI/Configuration Changes
  - Added a dependent checkbox for enabling detailed pre-round announcements, which is only active when the basic distribution option is checked.
